### PR TITLE
adding file for generic subsampling of bed files

### DIFF
--- a/dREG_paper_analyses/validation/generic_subsample.py
+++ b/dREG_paper_analyses/validation/generic_subsample.py
@@ -29,14 +29,16 @@ num_lines = sum(1 for line in open(infile_path))
 print 'There are', num_lines,'lines in', infile_path+'!'
 
 if millions == True:
+    print 'Interpreting input as millions.'
     for num in num_list:
         prob = num*(1000000.0)/num_lines
-        path = re.sub('.bed', '_'+str(num)+'m.bed', infile_path)
+        path = re.sub('.bed', '_'+str(int(num))+'m.bed', infile_path)
         if not '.gz' in infile_path:
             path = path+'.gz'
         outfile = gzip.open(path, 'w')
         subsamps.append((prob, outfile))
 else:
+    print 'Interpreting input as fractions.'
     for num in num_list:
         prob = num
         path = re.sub('.bed', '_'+str(int(num*100))+'pc.bed', infile_path)


### PR DESCRIPTION
Takes an optionally gzipped bed file and a list of desired subsampled output sizes, either in millions of lines or fractions of original (detects which option under the assumption that you will not ask solely for fractional millions), runs through bed file (technically twice - initially to get its size) and creates them all. Outputs are gzipped.
